### PR TITLE
added response time for apache access log

### DIFF
--- a/config_handler/mapping/logging_plugins_mapping.yaml
+++ b/config_handler/mapping/logging_plugins_mapping.yaml
@@ -75,7 +75,7 @@ apache-error:
 apache-access:
    source:
      '@type': tail
-     format: '/^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/'
+     format: '/^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" (?<response_time>[^ ]*))?$/'
      time_format: '%d/%b/%Y:%H:%M:%S %z'
      keep_time_key: 'true'
      path: '/var/log/apache2/access.log, /var/log/httpd/access_log'


### PR DESCRIPTION
Expected log format now for apache is
LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %D" combined

here "%D" is not added by default, the user needs to add the format string with a whitespace and restart apache 
  